### PR TITLE
Changed the name of a configuration file, because of a change in the …

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -6,7 +6,7 @@
 # a well known location for one of the containers ('otree')
 
 # Define the Nginx configuration file path
-nginx_conf="/etc/nginx/conf.d/ssl_main.conf"
+nginx_conf="/etc/nginx/conf.d/tls_main.conf"
 
 # Define two variables containing the correct reverse proxy configuration for
 # the two Docker containers


### PR DESCRIPTION
…nginx component on Research Cloud:

"Due to the change a SSL configuration file was renamed: Old path: /etc/nginx/conf.d/ssl_main.conf
New path: /etc/nginx/conf.d/tls_main.conf"